### PR TITLE
Mocha dependecies (such as minimatch) are not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "simple REST service to check the health of all our services and report it back",
   "main": "index.js",
   "scripts": {
-    "pretest": "npm install --only=dev",
+    "pretest": "npm install",
     "test": "mocha --timeout 10000 --recursive --reporter mocha-junit-reporter --reporter-options testCaseSwitchClassnameAndName=true",
     "start": "node index.js"
   },


### PR DESCRIPTION
Mocha dependecies (such as minimatch) are not installed when using npm install dev-only.
Change the npm test command to fix this.