### PR TITLE
Add a timeout to the heath check requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.13.0-alpine
+FROM node:10.15-alpine
 
 WORKDIR /app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('Build and package') { 
              agent {
                 docker {
-                    image 'node:10.13.0-alpine'
+                    image 'node:10.15-alpine'
                 }
             }
             steps { 

--- a/env.js
+++ b/env.js
@@ -19,19 +19,26 @@ var logger = bunyan.createLogger({
 module.exports = (function() {
   var env = {};
   //port on which to expose the service
-  env.servicePort = process.env.SERVICE_PORT || 8080
+  env.servicePort = process.env.SERVICE_PORT || 8080;
   // The service
   env.serviceName = process.env.SERVICE_NAME || "health-check";
+  env.pingTimeout = JSON.parse(process.env.PING_TIMEOUT) || 5000;
   // list of urls to monitor
   // exemple: [{"name": "svc1", "url":"https://.../status"},{"name": "svc2", "url":"https://.../status"}]
   var monitored_urls = process.env.MONITORED_URLS;
   if(monitored_urls) {
     try {
       env.monitoredServices = JSON.parse(monitored_urls);
+      for(let i=0; i<env.monitoredServices.length; i++) {
+        if (!env.monitoredServices[i].pingTimeout) {
+          env.monitoredServices[i].pingTimeout =  env.pingTimeout;
+        }
+      }
     } catch(err) {
       logger.error("Error while parsing the list of monitored services: " + err);
     }
   }
+  
   
 
   //Log config

--- a/service.js
+++ b/service.js
@@ -40,11 +40,11 @@ class HealthCheckService {
 
         return new Promise((resolve, reject) => {
             var retVal = { 'service': service.name };
-
             // prepare request:
             var options = {
                 method: 'GET',
                 uri: service.url,
+                timeout: service.pingTimeout,
                 transform: function (body, response, resolveWithFullResponse) {
                     return { 'statusCode': response.statusCode, 'data': body };
                 }

--- a/test/test_env.js
+++ b/test/test_env.js
@@ -1,0 +1,28 @@
+let chai = require('chai');
+let should = chai.should();
+
+describe("Configuration", () => {
+    let config;
+    before(() => {
+        process.env.MONITORED_URLS = JSON.stringify([
+            {name: "gatekeeper", url:"http://localhost:9123/status"},
+            {name: "hakken", url:"http://localhost:8000/status", "pingTimeout": 3000},
+        ]);
+        process.env.PING_TIMEOUT = 4000;
+        config = require("../env.js");
+    });
+    it("Service urls should be parsed correctly", () => {
+        config.monitoredServices.should.deep.contain(
+            {name: "gatekeeper", url:"http://localhost:9123/status", "pingTimeout": 4000},
+            {name: "hakken", url:"http://localhost:8000/status", "pingTimeout": 3000});
+    }); 
+    it("Global ping timeout should be correctly set", () => {
+        config.pingTimeout.should.eql(4000);
+    });
+    it("Gatekeeper ping timeout should be set with the default value", () => {
+        config.monitoredServices[0].pingTimeout.should.eql(4000);
+    });
+    it("Hakken ping timeout should be set with a custom value", () => {
+        config.monitoredServices[1].pingTimeout.should.eql(3000);
+    });
+});

--- a/test/test_service.js
+++ b/test/test_service.js
@@ -9,9 +9,9 @@ chai.use(chaiHttp);
 describe('Global health check service', () => {
     
     var testServices = [
-        {"name": "shoreline", "url":"http://my.services.com/auth/status"},
-        {"name": "gatekeeper", "url":"http://my.services.com/access/status"},
-        {"name": "tide-whisperer", "url":"http://my.services.com/data/status"}
+        {name: "shoreline", url:"http://my.services.com/auth/status", pingTimeout: 5000},
+        {name: "gatekeeper", url:"http://my.services.com/access/status", pingTimeout: 5000},
+        {name: "tide-whisperer", url:"http://my.services.com/data/status", pingTimeout: 5000}
     ];
     var svc = new Service(testServices);
     svc.logger.level('warn');

--- a/test/test_service.js
+++ b/test/test_service.js
@@ -46,12 +46,12 @@ describe('Global health check service', () => {
             statusResults[2].details.should.eql("OK");
         });
     });
-    describe('When one service does not respond', () => {
+    describe('When one service is down', () => {
         let statusResults = [];
         before(() => {
             //redefine mock urls to make one of them to fail:
             nock.cleanAll();
-            services.get('/auth/status').reply(500, "cannot reach server")
+            services.get('/auth/status').reply(500, "service is down")
                     .get('/access/status').reply(200,"OK")
                     .get('/data/status').reply(200,"OK");
         });
@@ -67,7 +67,31 @@ describe('Global health check service', () => {
         it('should return an error for shoreline', () => {           
             let authStatus = statusResults.filter(status => status.service == "shoreline");
             authStatus[0].status.should.eql("NOK");
-            authStatus[0].error.should.eql("500 - \"cannot reach server\"");
+            authStatus[0].error.should.eql("500 - \"service is down\"");
+        })
+    });
+    describe('When one service does not respond in a timely manner (timeout)', () => {
+        let statusResults = [];
+        before(() => {
+            //redefine mock urls to make one of them to fail:
+            nock.cleanAll();
+            services.get('/auth/status').reply(200, "OK")
+                    .get('/access/status').reply(200,"OK")
+                    .get('/data/status').delay(6000).reply(200,"mongo ping failed");
+        });
+        it('the service should return an http error 503 and an array of 3 items', (done) => {
+            chai.request(svc.server).get('/status').end((err,res) => {
+                res.should.have.status(503);
+                statusResults = res.body;
+                res.body.should.be.a('array');
+                res.body.length.should.eql(3);
+                done();
+            });
+        });
+        it('should return an error for tide-whisperer', () => {           
+            let authStatus = statusResults.filter(status => status.service == "tide-whisperer");
+            authStatus[0].status.should.eql("NOK");
+            //authStatus[0].error.should.eql("500 - \"cannot reach server\"");
         })
     });
     describe('Body content should be correctly parsed', () => {


### PR DESCRIPTION
Some GO services which ping the mongo db to check the service status will take sometime before responding (this is because the the mongo ping takes a long time before failing).
To solve this issue we need the healthcheck requests to timeout.