### PR TITLE
Feature/review ci params docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This end point is typically what would be provided to a load balancer to check t
 ## Unreleased
 ### Engineering
 - Modify pipeline so the publish to Operations docker registry is effective
+- Modify CI parameters to accomodate changes in Jenkins library for publishing SOUP/OPENAPI
 
 ## 1.2.3 - 2020-09-30
 ### Engineering

--- a/ci.yml
+++ b/ci.yml
@@ -6,5 +6,5 @@ docker: true
 dockerPictime: true
 publishNpm: false
 publishS3: true
-publishSoup: true
+publishSoupBucket: com.diabeloop.backloops.docs
 dockerPushToProduction: true


### PR DESCRIPTION
This PR is dependent on Jenkins library PR (https://bitbucket.org/diabeloop/jenkins-pipeline-library/pull-requests/14/feature-review-openapi-publish-trigger)

Once Jenkins is approved and merged, we can remove the last commit to use the master branch of the lib instead of temp.